### PR TITLE
fix run align not working due to arguments and device allocation

### DIFF
--- a/aligner/sent_aligner.py
+++ b/aligner/sent_aligner.py
@@ -121,7 +121,7 @@ def word_align(args, tokenizer, model, folder_path, src_path, tgt_path):
         with torch.no_grad():
             ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt, sents_src, sents_tgt = batch
 
-            ids_src, ids_tgt = ids_src, ids_tgt
+            ids_src, ids_tgt = ids_src.to(args.device), ids_tgt.to(args.device)
             word_aligns_list_all_layer_dic_one_batch = model_sentence.get_aligned_word(args, ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt, tokenizer.pad_token_id, tokenizer.cls_token_id, tokenizer.sep_token_id, output_prob = False)
 
             for layer_id in word_aligns_list_all_layer_dic_one_batch:

--- a/aligner/word_align.py
+++ b/aligner/word_align.py
@@ -46,8 +46,7 @@ class SentenceAligner_word(object):
         output_src,output_tgt = self.embed_loader(
             inputs_src=inputs_src, inputs_tgt=inputs_tgt, attention_mask_src=(inputs_src != PAD_ID),
             attention_mask_tgt=(inputs_tgt != PAD_ID), guide=None, align_layer=args.align_layer,
-            extraction=args.extraction, softmax_threshold=args.softmax_threshold,
-            train_so=args.train_so, train_co=args.train_co, do_infer=True,
+            extraction=args.extraction, softmax_threshold=args.softmax_threshold, do_infer=True
         )
 
         align_matrix_all_layers = {}


### PR DESCRIPTION
Fix part of the code that handles generating alignment (referring to [this issue](https://github.com/sufenlp/AccAlign/issues/2#issue-1627400190)).

In `word_align.py`, I removed the `train_so` and` train_co `arguments as it is not used during inference (I checked the flow and the training/validation steps are not touching this part of the code).

Moreover, in `sent_aligner.py` specifically in the `word_align()` function, I explicitly move the `ids_src` and `ids_tgt` to `args.device` (or else the code will complain about the tensors residing in the CPU while the model in GPU).
